### PR TITLE
Add the Zenodo DOI

### DIFF
--- a/CITATION
+++ b/CITATION
@@ -3,4 +3,4 @@ Please cite as:
 Christie Bahlai and Tracy Teal (eds): "Data Organization in Spreadsheets."
 Version 2017.01, May 2017,
 https://github.com/datacarpentry/spreadsheet-ecology-lesson,
-FIXME: Add Zenodo DOI.
+http://doi.org/10.5281/zenodo.570047.


### PR DESCRIPTION
One of the participants in my NEON/QUBES FMN is citing this lesson and still had the FIXME text in the citation. This appears to be the correct DOI.  Feel free to reject PR if not.
